### PR TITLE
Fixing reveal logic

### DIFF
--- a/src/MinesweeperLogic.py
+++ b/src/MinesweeperLogic.py
@@ -342,14 +342,14 @@ class MinesweeperLogic:
         """
         if(self._isAllowed(cell)):
             return (
-               cell - self.COLS,
-               cell - self.COLS + 1,
+               cell - self.MAP_BOUNDARIES_COLS,
+               cell - self.MAP_BOUNDARIES_COLS + 1,
                cell + 1,
-               cell + self.COLS + 1,
-               cell + self.COLS,
-               cell + self.COLS - 1,
+               cell + self.MAP_BOUNDARIES_COLS + 1,
+               cell + self.MAP_BOUNDARIES_COLS,
+               cell + self.MAP_BOUNDARIES_COLS - 1,
                cell - 1,
-               cell - self.COLS - 1,
+               cell - self.MAP_BOUNDARIES_COLS - 1,
             )
         else:
             return ()
@@ -412,14 +412,13 @@ class MinesweeperLogic:
                     
                 # If no adjacent mines, add neighboring allowed cells to the reveal queue
                 if NUM == 0:
-                    neighbors = np.array(self._getNeighbors(one_cell))
-                    cells_to_be_revealed.extend(self.get_allowed_of(neighbors))
+                    neighbors = np.asarray(self._getNeighbors(one_cell))
+                    neighbors = self.get_allowed_of(neighbors)
+                    cells_to_be_revealed.extend(neighbors)
         return NEW_GRID
 
     def get_allowed_of(self, cells:ndarray):
-        
-        
-        return cells[np.isin(cells, self.ALLOWED_CELLS)]
+        return cells[self._isAllowed(cells)]
     
     def _getFlagNumber(self, cell:uint16, grid = GRID) -> uint8:
         if (self._isForbidden(cell)):
@@ -502,7 +501,7 @@ class MinesweeperLogic:
             return "Minesweeper board not initialized."
 
         lines = []
-        for r in range(self.ROWS):
+        for r in range(self.MAP_BOUNDARIES_ROWS):
             row_cells = self.GRID[r * self.MAP_BOUNDARIES_COLS: (r + 1) * self.MAP_BOUNDARIES_COLS]
             row_str = " ".join(self._cell_repr(cell) for cell in row_cells)
             lines.append(row_str)
@@ -522,4 +521,4 @@ class MinesweeperLogic:
         elif cell == CELL_STATE.MINE:
             return "*"  # Mines
         else:
-            return str(cell)  # Default: Use numeric values
+            return str(int(cell))  # Default: Use numeric values


### PR DESCRIPTION
_getNeighbors calculated the index of neigboring cells based on the length of cols ignoring that there are forbidden cells, that lead to wrong results. Fixed, by using the MAP_BOUNDARIES_COLS instead of COLS.

making the code where neighbors are added, to the to_be_reveald queue more readable, to avoid future confusion

removed inefficient code from get_allowed_of(), it used to compair the elements of two arrays, one of them unnessessary large. Now a mask is used to avoid calculations on unnecessary cells. This improves the worst case time complexity from O(n log n) to O(n).

fixed __str__() where the calculation of the begin and end of each line was based only on allowed cells, which did cause issues with the forbidden cells

fixed _cell_repr() fixed misalignment of numbers by removing floating zeros via int() cast